### PR TITLE
fix an error when post.html is null + downloads "feature_image"

### DIFF
--- a/src/downloader.js
+++ b/src/downloader.js
@@ -3,11 +3,16 @@ const axios = require( "axios" );
 
 module.exports.doTheDownloads = async ( { jsonFile, baseUrl, basePath }, logger ) => {
 	const parseImages = post => {
-		let matches;
-		if ( post.html ) {
-			matches = post.html.match( /(?<=src="\/)content[^"]*/gi );
+		const findImages = () => post.html.match( /(?<=src="\/)content[^"]*/gi );
+		let matches = [];
+		if ( post.feature_image ) {
+			matches.push( post.feature_image );
 		}
-		return matches || [];
+		if ( post.html && findImages() ) {
+			matches = [ ...matches, ...findImages() ];
+		}
+
+		return matches;
 	};
 
 	const downloadImage = ( url, localPath ) => {

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -3,7 +3,10 @@ const axios = require( "axios" );
 
 module.exports.doTheDownloads = async ( { jsonFile, baseUrl, basePath }, logger ) => {
 	const parseImages = post => {
-		const matches = post.html.match( /(?<=src="\/)content[^"]*/gi );
+		let matches;
+		if ( post.html ) {
+			matches = post.html.match( /(?<=src="\/)content[^"]*/gi );
+		}
 		return matches || [];
 	};
 


### PR DESCRIPTION
Trying to download a Ghost website's images, I realized that some "post" object does not have a "html" key and that crashes everything. Adding a condition allows to avoid it.

The other thing is that the post object contains a key "feature_image" that was ignored and so this PR ads it.